### PR TITLE
Use English instead of Latin names

### DIFF
--- a/Styles/IHM.json
+++ b/Styles/IHM.json
@@ -346,7 +346,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "line-center",
@@ -3879,7 +3878,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -3906,7 +3904,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4009,7 +4006,6 @@
           [
             "coalesce",
             ["get", "name:he"],
-            ["get", "name:latin"],
             ["get", "name"]
           ],
           " ",
@@ -4064,7 +4060,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4089,7 +4084,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4115,7 +4109,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4142,7 +4135,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4169,7 +4161,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4195,7 +4186,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4252,7 +4242,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4299,7 +4288,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4331,7 +4319,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4363,7 +4350,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -4434,7 +4420,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4471,7 +4456,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "icon-size": {"stops": [[14, 0.4], [20, 0.7]]},
@@ -4502,7 +4486,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4542,7 +4525,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4570,7 +4552,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4598,7 +4579,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4630,7 +4610,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4660,7 +4639,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4687,7 +4665,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -4748,7 +4725,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4777,7 +4753,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "icon-size": {"stops": [[14, 0.4], [20, 0.7]]},
@@ -4834,7 +4809,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "icon-size": {"stops": [[14, 0.4], [20, 0.7]]},
@@ -4862,7 +4836,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -4904,7 +4877,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -4964,7 +4936,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -4995,7 +4966,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-size": 18,
@@ -5025,7 +4995,6 @@
             [
               "coalesce",
               ["get", "name:he"],
-              ["get", "name:latin"],
               ["get", "name"]
             ]
           ]
@@ -5035,7 +5004,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Cond Bold"],
@@ -5061,7 +5029,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -5088,7 +5055,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -5115,7 +5081,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -5143,7 +5108,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -5171,7 +5135,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",
@@ -5198,7 +5161,6 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
           ["get", "name"]
         ],
         "symbol-placement": "point",

--- a/Styles/IHM.json
+++ b/Styles/IHM.json
@@ -3748,10 +3748,10 @@
       "minzoom": 14,
       "filter": ["==", "class", "tower"],
       "paint": {
-        "circle-radius": 2.5,
+        "circle-radius": {"stops": [[14, 2.5], [20, 4]]},
         "circle-stroke-color": "#bbb",
         "circle-opacity": 0,
-        "circle-stroke-width": 1.5
+        "circle-stroke-width": {"stops": [[14, 1.5], [20, 2.4]]}
       }
     },
     {
@@ -4248,7 +4248,7 @@
       ],
       "layout": {
         "icon-image": "holy_place",
-        "icon-size": 0.5,
+        "icon-size": {"stops": [[14, 0.5], [20, 0.8]]},
         "text-field": [
           "coalesce",
           ["get", "name:he"],
@@ -4278,7 +4278,10 @@
         ["==", "subclass", "jewish"],
         ["in", "class", "place_of_worship", "monastery"]
       ],
-      "layout": {"icon-image": "synagogue", "icon-size": 0.5}
+      "layout": {
+        "icon-image": "synagogue",
+        "icon-size": {"stops": [[14, 0.5], [20, 0.8]]}
+      }
     },
     {
       "id": "icon-muslim",
@@ -4292,7 +4295,7 @@
       ],
       "layout": {
         "icon-image": "mosque",
-        "icon-size": 0.5,
+        "icon-size": {"stops": [[14, 0.5], [20, 0.8]]},
         "text-field": [
           "coalesce",
           ["get", "name:he"],
@@ -4324,7 +4327,7 @@
       ],
       "layout": {
         "icon-image": "church",
-        "icon-size": 0.5,
+        "icon-size": {"stops": [[14, 0.5], [20, 0.8]]},
         "text-field": [
           "coalesce",
           ["get", "name:he"],
@@ -4471,7 +4474,7 @@
           ["get", "name:latin"],
           ["get", "name"]
         ],
-        "icon-size": 0.4,
+        "icon-size": {"stops": [[14, 0.4], [20, 0.7]]},
         "icon-allow-overlap": true,
         "text-font": ["Open Sans Cond Bold"],
         "text-anchor": "top",
@@ -4777,7 +4780,7 @@
           ["get", "name:latin"],
           ["get", "name"]
         ],
-        "icon-size": 0.4,
+        "icon-size": {"stops": [[14, 0.4], [20, 0.7]]},
         "icon-allow-overlap": true,
         "text-font": ["Open Sans Cond Bold"],
         "text-anchor": "top",
@@ -4800,7 +4803,10 @@
       "source-layer": "poi",
       "minzoom": 12,
       "filter": ["==", "subclass", "cistern"],
-      "paint": {"circle-color": "white", "circle-radius": 5.5}
+      "paint": {
+        "circle-color": "white",
+        "circle-radius": {"stops": [[14, 6.2], [20, 10.85]]}
+      }
     },
     {
       "id": "water-cistern-circle",
@@ -4810,10 +4816,10 @@
       "minzoom": 12,
       "filter": ["==", "subclass", "cistern"],
       "paint": {
-        "circle-radius": 2.5,
+        "circle-radius": {"stops": [[14, 2.5], [20, 4.375]]},
         "circle-color": "rgba(0,0,0,0)",
         "circle-stroke-color": "#1E80E2",
-        "circle-stroke-width": 2.5
+        "circle-stroke-width": {"stops": [[14, 2.5], [20, 4.375]]}
       }
     },
     {
@@ -4831,7 +4837,7 @@
           ["get", "name:latin"],
           ["get", "name"]
         ],
-        "icon-size": 0.4,
+        "icon-size": {"stops": [[14, 0.4], [20, 0.7]]},
         "icon-allow-overlap": true,
         "text-font": ["Open Sans Cond Bold"],
         "text-anchor": "top",
@@ -4880,10 +4886,10 @@
       "minzoom": 12,
       "filter": ["in", "subclass", "spring", "pond", "stream_pool"],
       "paint": {
-        "circle-radius": 5,
+        "circle-radius": {"stops": [[14, 5], [20, 8.75]]},
         "circle-color": "#1E80E2",
         "circle-stroke-color": "white",
-        "circle-stroke-width": 1.2
+        "circle-stroke-width": {"stops": [[14, 1.2], [20, 2.1]]}
       }
     },
     {

--- a/Styles/ilMTB.json
+++ b/Styles/ilMTB.json
@@ -44,6 +44,31 @@
       }
     },
     {
+      "id": "land-construction",
+      "type": "fill",
+      "source": "IHM",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "filter": ["all", ["in", "class", "construction"]],
+      "paint": {
+        "fill-color": "rgba(192, 192, 192, 1)",
+        "fill-outline-color": "rgba(170, 170, 170, 1)"
+      }
+    },
+    {
+      "id": "land-construction-pattern",
+      "type": "symbol",
+      "source": "IHM",
+      "source-layer": "landuse",
+      "minzoom": 14,
+      "filter": ["all", ["in", "class", "construction"]],
+      "layout": {
+        "icon-image": "construction",
+        "icon-size": {"stops": [[14, 0.5], [21, 2]]}
+      },
+      "paint": {}
+    },
+    {
       "id": "land_sand",
       "type": "fill",
       "source": "IHM",
@@ -760,6 +785,37 @@
       "paint": {
         "line-color": "rgba(102, 102, 102, 1)",
         "line-width": {"base": 1.4, "stops": [[4, 1], [20, 55]]}
+      }
+    },
+    {
+      "id": "road_construction",
+      "type": "line",
+      "metadata": {"IHM:overlay": true},
+      "source": "IHM",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["in", "ilmtb_class", "minor_construction", "tertiary_construction"],
+        ["!=", "brunnel", "tunnel"]
+      ],
+      "paint": {"line-width": {"stops": [[14, 3], [16, 6], [20, 18]]}}
+    },
+    {
+      "id": "road_construction core",
+      "type": "line",
+      "metadata": {"IHM:overlay": true},
+      "source": "IHM",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["in", "ilmtb_class", "minor_construction", "tertiary_construction"],
+        ["!=", "brunnel", "tunnel"]
+      ],
+      "paint": {
+        "line-color": "white",
+        "line-width": {"base": 1.55, "stops": [[14, 2], [20, 15]]}
       }
     },
     {

--- a/Styles/ilMTB.json
+++ b/Styles/ilMTB.json
@@ -1950,7 +1950,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 3,
@@ -2006,7 +2006,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 3,
@@ -2060,7 +2060,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2088,7 +2088,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2180,7 +2180,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2260,7 +2260,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2287,7 +2287,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2313,7 +2313,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2345,7 +2345,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2377,7 +2377,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2409,7 +2409,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2441,7 +2441,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2473,7 +2473,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2574,7 +2574,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2673,7 +2673,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2704,7 +2704,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2731,7 +2731,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2758,7 +2758,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2789,7 +2789,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2820,7 +2820,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2851,7 +2851,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2883,7 +2883,7 @@
           [
             "coalesce",
             ["get", "name:he"],
-            ["get", "name:latin"],
+            ["get", "name_en"],
             ["get", "name"]
           ]
         ],
@@ -2912,7 +2912,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -2959,7 +2959,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -2987,7 +2987,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -3015,7 +3015,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -3043,7 +3043,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -3106,7 +3106,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -3165,7 +3165,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3203,7 +3203,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3231,7 +3231,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3259,7 +3259,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3287,7 +3287,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3369,7 +3369,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -3393,7 +3393,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3414,7 +3414,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3435,7 +3435,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3457,7 +3457,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3488,7 +3488,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3509,7 +3509,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3534,7 +3534,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3563,7 +3563,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Regular"],
@@ -3592,7 +3592,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-font": ["Open Sans Bold"],
@@ -3624,7 +3624,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "text-max-width": 5,
@@ -3650,7 +3650,7 @@
         "text-field": [
           "coalesce",
           ["get", "name:he"],
-          ["get", "name:latin"],
+          ["get", "name_en"],
           ["get", "name"]
         ],
         "symbol-placement": "point",

--- a/Styles/ilMTB.json
+++ b/Styles/ilMTB.json
@@ -1853,175 +1853,6 @@
       }
     },
     {
-      "id": "airport-taxiway",
-      "type": "line",
-      "source": "IHM",
-      "source-layer": "aeroway",
-      "minzoom": 14,
-      "filter": ["all", ["==", "class", "taxiway"]],
-      "paint": {
-        "line-color": "rgba(129, 126, 126, 1)",
-        "line-width": {"stops": [[12, 2], [20, 15]]}
-      }
-    },
-    {
-      "id": "airport-runway",
-      "type": "line",
-      "source": "IHM",
-      "source-layer": "aeroway",
-      "minzoom": 11,
-      "filter": ["all", ["==", "class", "runway"]],
-      "paint": {
-        "line-color": "rgba(129, 126, 126, 1)",
-        "line-width": {"stops": [[11, 2.5], [20, 25]]}
-      }
-    },
-    {
-      "id": "airfield-symbol",
-      "type": "symbol",
-      "source": "IHM",
-      "source-layer": "landuse",
-      "minzoom": 10,
-      "maxzoom": 13,
-      "filter": [
-        "all",
-        ["==", "class", "military"],
-        ["==", "military", "airfield"]
-      ],
-      "layout": {
-        "text-size": 11,
-        "text-font": ["Open Sans Regular"],
-        "text-offset": [0, 0.5],
-        "text-anchor": "top",
-        "text-max-width": 3,
-        "icon-pitch-alignment": "map",
-        "icon-image": "airfield",
-        "icon-size": {"stops": [[10, 0.5], [15, 1]]},
-        "icon-padding": 300
-      },
-      "paint": {
-        "text-color": "#666",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-halo-blur": 1
-      }
-    },
-    {
-      "id": "airfield-label",
-      "type": "symbol",
-      "source": "IHM",
-      "source-layer": "landuse",
-      "minzoom": 13,
-      "maxzoom": 22,
-      "filter": [
-        "all",
-        ["==", "class", "military"],
-        ["==", "military", "airfield"]
-      ],
-      "layout": {
-        "text-size": 11,
-        "text-font": ["Open Sans Regular"],
-        "text-offset": [0, 0.5],
-        "icon-pitch-alignment": "map",
-        "icon-image": "airfield",
-        "icon-size": {"stops": [[10, 0.5], [15, 1]]},
-        "icon-padding": 300
-      },
-      "paint": {
-        "text-color": "#666",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-halo-blur": 1
-      }
-    },
-    {
-      "id": "airport-international-label",
-      "type": "symbol",
-      "source": "IHM",
-      "source-layer": "aerodrome_label",
-      "minzoom": 10,
-      "maxzoom": 15,
-      "filter": ["all", ["has", "iata"], ["==", "class", "international"]],
-      "layout": {
-        "text-size": {"stops": [[10, 12], [16, 20]]},
-        "text-font": ["Open Sans Regular"],
-        "text-offset": [0, 0.5],
-        "text-anchor": "top",
-        "text-field": [
-          "coalesce",
-          ["get", "name:he"],
-          ["get", "name_en"],
-          ["get", "name"]
-        ],
-        "text-max-width": 3,
-        "icon-pitch-alignment": "map",
-        "icon-image": "airfield",
-        "icon-size": {"stops": [[10, 0.5], [15, 1]]}
-      },
-      "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-halo-blur": 1
-      }
-    },
-    {
-      "id": "airport-symbol",
-      "type": "symbol",
-      "source": "IHM",
-      "source-layer": "aerodrome_label",
-      "minzoom": 10,
-      "maxzoom": 12,
-      "filter": ["all", ["has", "iata"]],
-      "layout": {
-        "text-size": {"stops": [[10, 18], [15, 24]]},
-        "text-font": ["Open Sans Regular"],
-        "text-offset": [0, 0.5],
-        "text-anchor": "top",
-        "text-max-width": 3,
-        "icon-pitch-alignment": "map",
-        "icon-image": "airfield",
-        "icon-size": {"stops": [[10, 0.5], [15, 1]]}
-      },
-      "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-halo-blur": 1
-      }
-    },
-    {
-      "id": "airport-label",
-      "type": "symbol",
-      "source": "IHM",
-      "source-layer": "aerodrome_label",
-      "minzoom": 12,
-      "maxzoom": 15,
-      "filter": ["all", ["has", "iata"]],
-      "layout": {
-        "text-size": {"stops": [[10, 18], [15, 24]]},
-        "text-font": ["Open Sans Regular"],
-        "text-offset": [0, 0.5],
-        "text-anchor": "top",
-        "text-field": [
-          "coalesce",
-          ["get", "name:he"],
-          ["get", "name_en"],
-          ["get", "name"]
-        ],
-        "text-max-width": 3,
-        "icon-pitch-alignment": "map",
-        "icon-image": "airfield",
-        "icon-size": {"stops": [[10, 0.5], [15, 1]]}
-      },
-      "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,0.75)",
-        "text-halo-blur": 1
-      }
-    },
-    {
       "id": "building_regular",
       "type": "fill-extrusion",
       "source": "IHM",
@@ -2880,12 +2711,7 @@
           "concat",
           ["get", "ele"],
           "\n\n",
-          [
-            "coalesce",
-            ["get", "name:he"],
-            ["get", "name_en"],
-            ["get", "name"]
-          ]
+          ["coalesce", ["get", "name:he"], ["get", "name_en"], ["get", "name"]]
         ],
         "icon-anchor": "center",
         "text-padding": 0,
@@ -3379,6 +3205,200 @@
       "paint": {
         "text-halo-width": 2,
         "text-halo-color": "rgba(255,255,255,0.75)"
+      }
+    },
+    {
+      "id": "airport-taxiway",
+      "type": "line",
+      "source": "IHM",
+      "source-layer": "aeroway",
+      "minzoom": 14,
+      "filter": ["all", ["==", "class", "taxiway"]],
+      "paint": {
+        "line-color": "rgba(129, 126, 126, 1)",
+        "line-width": {"stops": [[12, 2], [20, 15]]}
+      }
+    },
+    {
+      "id": "airport-runway",
+      "type": "line",
+      "source": "IHM",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "filter": ["all", ["==", "class", "runway"]],
+      "paint": {
+        "line-color": "rgba(129, 126, 126, 1)",
+        "line-width": {"stops": [[11, 2.5], [20, 25]]}
+      }
+    },
+    {
+      "id": "airport-symbol",
+      "type": "symbol",
+      "source": "IHM",
+      "source-layer": "aerodrome_label",
+      "minzoom": 10,
+      "maxzoom": 12,
+      "filter": ["all", ["has", "iata"]],
+      "layout": {
+        "text-size": {"stops": [[10, 18], [15, 24]]},
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "text-anchor": "top",
+        "text-max-width": 3,
+        "icon-pitch-alignment": "map",
+        "icon-image": "airfield",
+        "icon-size": {"stops": [[10, 0.5], [15, 1]]}
+      },
+      "paint": {
+        "text-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,0.75)",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "airport-label",
+      "type": "symbol",
+      "source": "IHM",
+      "source-layer": "aerodrome_label",
+      "minzoom": 10,
+      "maxzoom": 16,
+      "filter": ["all", ["has", "iata"]],
+      "layout": {
+        "text-size": {"stops": [[10, 12], [16, 20]]},
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "text-anchor": "top",
+        "text-field": [
+          "coalesce",
+          ["get", "name:he"],
+          ["get", "name_en"],
+          ["get", "name"]
+        ],
+        "text-max-width": 3,
+        "icon-pitch-alignment": "map",
+        "icon-image": "airfield",
+        "icon-size": {"stops": [[10, 0.5], [15, 1]]}
+      },
+      "paint": {
+        "text-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,0.75)",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "airbase-symbol",
+      "type": "symbol",
+      "source": "IHM",
+      "source-layer": "landuse",
+      "minzoom": 11,
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        ["==", "class", "military"],
+        ["==", "military", "airfield"]
+      ],
+      "layout": {
+        "text-size": 11,
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "text-anchor": "top",
+        "text-max-width": 3,
+        "icon-pitch-alignment": "map",
+        "icon-image": "airfield",
+        "icon-size": {"stops": [[10, 0.5], [15, 1]]},
+        "icon-padding": 300
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,0.75)",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "airbase-label",
+      "type": "symbol",
+      "source": "IHM",
+      "source-layer": "landuse",
+      "minzoom": 13,
+      "maxzoom": 22,
+      "filter": [
+        "all",
+        ["==", "class", "military"],
+        ["==", "military", "airfield"]
+      ],
+      "layout": {
+        "text-size": 11,
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "icon-pitch-alignment": "map",
+        "icon-image": "airfield",
+        "icon-size": {"stops": [[10, 0.5], [15, 1]]},
+        "icon-padding": 300
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,0.75)",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "airfield-symbol",
+      "type": "symbol",
+      "source": "IHM",
+      "source-layer": "aerodrome_label",
+      "minzoom": 12,
+      "maxzoom": 15,
+      "filter": ["all", ["!has", "iata"]],
+      "layout": {
+        "text-size": {"stops": [[10, 18], [15, 24]]},
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "text-anchor": "top",
+        "text-max-width": 3,
+        "icon-pitch-alignment": "map",
+        "icon-image": "airfield",
+        "icon-size": {"stops": [[10, 0.5], [15, 1]]}
+      },
+      "paint": {
+        "text-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,0.75)",
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "airfield-label",
+      "type": "symbol",
+      "source": "IHM",
+      "source-layer": "aerodrome_label",
+      "minzoom": 13,
+      "maxzoom": 17,
+      "filter": ["all", ["!has", "iata"]],
+      "layout": {
+        "text-size": {"stops": [[10, 18], [15, 24]]},
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 0.5],
+        "text-anchor": "top",
+        "text-field": [
+          "coalesce",
+          ["get", "name:he"],
+          ["get", "name_en"],
+          ["get", "name"]
+        ],
+        "text-max-width": 3,
+        "icon-pitch-alignment": "map",
+        "icon-image": "airfield",
+        "icon-size": {"stops": [[10, 0.5], [15, 1]]}
+      },
+      "paint": {
+        "text-color": "rgba(0, 0, 0, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,0.75)",
+        "text-halo-blur": 1
       }
     },
     {


### PR DESCRIPTION
Given that name_en uses manually entered values instead of flawed transliteration and copies "name" if it is null, and given that Arab characters are not available