### PR TITLE
add purple_dot for Sea to Sea trail

### DIFF
--- a/Styles/IHM.json
+++ b/Styles/IHM.json
@@ -902,6 +902,7 @@
           "blue:white:blue_stripe",
           "blue",
           "purple:white:purple_stripe",
+          'purple_dot',
           "purple",
           "orange:white:orange_stripe",
           "orange",


### PR DESCRIPTION
I changed osmc_symbol of Sea to Sea trail from yellow:white:yellow_stripe to purple_dot and the trail disappear from the map.